### PR TITLE
chore: promote spring-boot-rest-prometheus-java17 to version 0.0.12

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -3,5 +3,6 @@ helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/nginx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+- path: helmfiles/jx-staging/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-staging
+repositories:
+- name: dev
+  url: http://bucketrepo-jx.13.214.197.247.nip.io
+releases:
+- chart: dev/spring-boot-rest-prometheus-java17
+  version: 0.0.12
+  name: spring-boot-rest-prometheus-java17
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
chore: promote spring-boot-rest-prometheus-java17 to version 0.0.12

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge